### PR TITLE
Clean UI input handling

### DIFF
--- a/DnD-Epic6/Mods/DnD-Epic6/meta.lsx
+++ b/DnD-Epic6/Mods/DnD-Epic6/meta.lsx
@@ -32,10 +32,10 @@
           <attribute id="Tags" type="LSWString" value="XP;Progression;Leveling" />
           <attribute id="Type" type="FixedString" value="Add-on" />
           <attribute id="UUID" type="FixedString" value="c8ecf3dd-b5ab-4041-b2e0-d2197845342f" />
-          <attribute id="Version64" type="int64" value="36169575309510063" />
+          <attribute id="Version64" type="int64" value="36169577456993725" />
           <children>
             <node id="PublishVersion">
-              <attribute id="Version64" type="int64" value="36169575309510063" />
+              <attribute id="Version64" type="int64" value="36169577456993725" />
             </node>
             <node id="Scripts" />
             <node id="TargetModes">


### PR DESCRIPTION
Escape key and controller button Y exit menus (feat details first, then feat selector).
Suppress key/controller button input to the main game while the feat UI is up.
Unfortunately, I cannot suppress mouse or controller axis interaction.