### PR TITLE
Moved export buttons to commands. Added commands to fix summon levels.

### DIFF
--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Client/UI/E6_FeatSelectorUI.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Client/UI/E6_FeatSelectorUI.lua
@@ -276,48 +276,6 @@ local function AddResetFeatsButton(win, windowDimensions, playerInfo)
     end
 end
 
----Adds a button to export the character's Epic 6 information.
----@param win ExtuiTreeParent The parent to add the button to.
----@param windowDimensions integer[] The dimensions of the window.
----@param playerInfo PlayerInformationType The player information.
-local function AddExportCharacterEpic6Button(win, windowDimensions, playerInfo)
-    local centerCell = CreateCenteredControlCell(win, "ExportEpic6Cell", windowDimensions[1] - 30)
-    local exportButton = centerCell:AddButton(Ext.Loca.GetTranslatedString("hc1014814g1ab8g4a6dg93e9g0e4667bb18b7")) -- Export Character Epic 6 Data
-    AddTooltip(exportButton):AddText("he6d7a765g378ag4eceg9618ge42bf8c7878d") -- Export the character to a file.
-    exportButton.OnClick = function()
-        E6_CloseUI()
-        Ext.Net.PostMessageToServer(NetChannels.E6_CLIENT_TO_SERVER_EXPORT_EPIC6, playerInfo.UUID)
-    end
-end
-
----Adds a button to export the character entity data.
----@param win ExtuiTreeParent The parent to add the button to.
----@param windowDimensions integer[] The dimensions of the window.
----@param playerInfo PlayerInformationType The player information.
-local function AddExportCharacterGameButton(win, windowDimensions, playerInfo)
-    local centerCell = CreateCenteredControlCell(win, "ExportGameCell", windowDimensions[1] - 30)
-    local exportButton = centerCell:AddButton(Ext.Loca.GetTranslatedString("h27d08b54g94d5g405cga8c6g57231379a05f")) -- Export Character Game Data
-    AddTooltip(exportButton):AddText("h5cb70d0agc32bg49d6g96f1gdd2daa2ac545") -- Export the character to a file.
-    exportButton.OnClick = function()
-        E6_CloseUI()
-        Ext.Net.PostMessageToServer(NetChannels.E6_CLIENT_TO_SERVER_EXPORT_EPIC6, playerInfo.UUID)
-    end
-end
-
----Adds a button to test some functionality (varies with usage/need).
----@param win ExtuiTreeParent The parent to add the button to.
----@param windowDimensions integer[] The dimensions of the window.
----@param playerInfo PlayerInformationType The player information.
-local function AddRunTestButton(win, windowDimensions, playerInfo)
-    local centerCell = CreateCenteredControlCell(win, "RunTest", windowDimensions[1] - 30)
-    local runTestButton = centerCell:AddButton("Run Test")
-    AddTooltip(runTestButton):AddText("Runs a test regarding Minsc and Jaheira")
-    runTestButton.OnClick = function()
-        E6_CloseUI()
-        Ext.Net.PostMessageToServer(NetChannels.E6_CLIENT_TO_SERVER_RUN_TEST, playerInfo.UUID)
-    end
-end
-
 ---Creates a slider that clamps the value and increments in 100's
 ---@param win ExtuiTreeParent The parent to add the button to.
 ---@param sliderName string The name of the slider
@@ -439,18 +397,6 @@ local function AddSettings(win, windowDimensions, playerInfo)
     win:AddSpacing()
     win:AddSpacing()
     AddResetFeatsButton(settings, windowDimensions, playerInfo)
-
-    win:AddSpacing()
-    win:AddSpacing()
-    AddExportCharacterEpic6Button(settings, windowDimensions, playerInfo)
-
-    win:AddSpacing()
-    win:AddSpacing()
-    AddExportCharacterGameButton(settings, windowDimensions, playerInfo)
-
-    --win:AddSpacing()
-    --win:AddSpacing()
-    --AddRunTestButton(settings, windowDimensions, playerInfo)
 end
 
 local windowTitle = Ext.Loca.GetTranslatedString("hb09763begcf50g4351gb1f1gd39ec792509b") -- Feats: {CharacterName}

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_Commands.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_Commands.lua
@@ -1,0 +1,181 @@
+
+---Exports the character's profile information to the file system as json. It skips numerous fields to avoid to much data (and redundancy).
+---@param _ string Command called
+---@param charId string Character ID
+local function ExportCharacter(_, charId, ...)
+    local entity = Ext.Entity.Get(charId)
+    if entity ~= nil then
+        --local datePrefix = os.date("%Y-%m-%d")
+        local character = GetCharacterName(entity)
+        E6_ToFile(entity, character .. "-Character-Export.json", {"Party", "ServerReplicationDependencyOwner", "InventoryContainer", "ServerRecruitedBy", "ServerOwneeHistory", "StatusManager"})
+    else
+        _E6Error("Failed find the character '" .. charId .. "' to export.")
+    end
+end
+
+---Exports the character's Epic 6 data to the file system as json.
+---@param _ string Command called
+---@param charId string Character ID
+local function ExportEpicSix(_, charId, ...)
+    local entity = Ext.Entity.Get(charId)
+    if not entity then
+        _E6Error("Failed to get the entity for the id: " .. charId)
+        return
+    end
+
+    --local datePrefix = os.date("%Y-%m-%d")
+    local playerInfo = GetFullPlayerInfo(entity)
+    if not playerInfo then
+        _E6Error("Failed to get the player info for: " .. charId)
+        return
+    end
+    local data = {
+        PlayerInfo = playerInfo,
+        SelectedFeats = entity.Vars.E6_Feats
+    }
+    local filename = playerInfo.Name .. "-EpicSix-Export.json"
+    Ext.IO.SaveFile(filename, Ext.Json.Stringify(data))
+    _E6P("Json data saved to %LOCALAPPDATA%\\Larian Studios\\Baldur's Gate 3\\Script Extender\\" .. filename .. ".")
+end
+
+---Gets the race of the entity if the name cannot be retrieved. Also returns the level if available.
+---@param entity EntityHandle Character ID to dump the party for.
+local function GetEntityInfo(entity)
+    local name = GetCharacterName(entity, true)
+    if name == nil then
+        if entity.Race then
+            local raceGuid = entity.Race.Race
+            ---@type ResourceRace
+            local race = Ext.StaticData.Get(raceGuid, Ext.Enums.ExtResourceManagerType.Race)
+            if race then
+                name = race.DisplayName:Get()
+            end
+        end
+    end
+    if name == nil then
+        name = "<unknown>"
+    end
+    local availableLevel = nil
+    if entity.AvailableLevel then
+        availableLevel = "Level " .. tostring(entity.AvailableLevel.Level)
+    end
+    local eocLevel = nil
+    if entity.EocLevel then
+        eocLevel = "EOC Level " .. tostring(entity.EocLevel.Level)
+    end
+    local level = nil
+    if availableLevel and eocLevel then
+        level = availableLevel .. ", " .. eocLevel
+    elseif availableLevel then
+        level = availableLevel
+    elseif eocLevel then
+        level = eocLevel
+    end
+    if level then
+        return name .. " (" .. level .. ")"
+    end
+    return name
+end
+
+---Iterates through the party views for the given character id, calling the function for each member.
+---@param charId string Character ID
+---@param onMember function The function to call for each member
+local function IterParty(charId, onMember)
+    local entity = Ext.Entity.Get(charId)
+    if not entity then
+        _E6Error("Failed to get the entity for the id: " .. charId)
+        return
+    end
+
+    if not entity.PartyMember then
+        _E6Error("Failed to get the party member for the entity: ".. charId)
+        return
+    end
+
+    if not entity.PartyMember.Party then
+        _E6Error("Failed to get the party member party for the entity: ".. charId)
+        return
+    end
+
+    if not entity.PartyMember.Party.PartyView then
+        _E6Error("Failed to get the party member party party view for the entity: ".. charId)
+        return
+    end
+
+    local partyView = entity.PartyMember.Party.PartyView
+
+    for i, v in ipairs(partyView.Views) do
+        for j, c in ipairs(v.Characters) do
+            onMember(i, j, c)
+        end
+    end
+end
+
+---Dumps the party members for the given character id, including summons.
+---@param _ string Command called 
+---@param charId string Character ID to dump the party for.
+local function DumpParty(_, charId)
+    _E6P("Views for: " .. charId)
+    local partyView = {}
+
+    IterParty(charId, function(i, j, c)
+        if not partyView[i] then
+            _E6P("  Party view: " .. tostring(i))
+            partyView[i] = true
+        end
+        _E6P("    Party member: " .. GetEntityInfo(c))
+    end)
+end
+
+---Attempts to fix the summons in the party for the given character id, but it doesn't work.
+---@param _ string Command called 
+---@param charId string Character ID to dump the party for.
+local function FixParty(_, charId)
+    _E6P("Views for: " .. charId)
+    local partyView = {}
+
+    IterParty(charId, function(i, j, c)
+        if not partyView[i] then
+            _E6P("  Party view: " .. tostring(i))
+            partyView[i] = true
+        end
+        _E6P("    Party member: " .. GetEntityInfo(c))
+        local changed = false
+        if c.AvailableLevel.Level > 6 then
+            c.AvailableLevel.Level = 6
+            changed = true
+        end
+        if c.EocLevel.Level > 6 then
+            c.EocLevel.Level = 6
+            changed = true
+        end
+        if changed then
+            _E6P("    Party member: " .. GetEntityInfo(c))
+        end
+    end)
+end
+
+local function TestFeatCount(xp, featXP, featXPDelta, expectedCount)
+    local count = GetFeatCountForXPBase(xp, featXP, featXPDelta)
+    local result = "XP=" .. tostring(xp) .. ", featXP=" .. tostring(featXP) .. ", featXPDelta=" .. tostring(featXPDelta) .. ", expected " .. tostring(expectedCount) .. " but got " .. tostring(count)
+    if count ~= expectedCount then
+        _E6Error(result)
+    else
+        _E6P(result)
+    end
+end
+
+---Tests the feat count calculation.
+local function TestXPCalc()
+    TestFeatCount(0, 1000, 0, 0)
+    TestFeatCount(1000, 1000, 0, 1)
+    TestFeatCount(1000, 1000, 1000, 1)
+    TestFeatCount(2000, 1000, 1, 1)
+    TestFeatCount(2001, 1000, 1, 2)
+end
+
+Ext.RegisterConsoleCommand("E6_ExportCharacter", ExportCharacter)
+Ext.RegisterConsoleCommand("E6_ExportEpicSix", ExportEpicSix)
+Ext.RegisterConsoleCommand("E6_DumpParty", DumpParty)
+Ext.RegisterConsoleCommand("E6_FixParty", FixParty)
+Ext.RegisterConsoleCommand("E6_TestXPCalc", TestXPCalc)

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_FeatPoints.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_FeatPoints.lua
@@ -3,7 +3,8 @@
 ---Closes the UI for the given character.
 ---@param char string The character ID
 function E6_NetCloseUI(char)
-    Ext.Net.PostMessageToClient(char, NetChannels.E6_SERVER_TO_CLIENT_CLOSE_UI, char)
+    local result = Ext.Net.PostMessageToClient(char, NetChannels.E6_SERVER_TO_CLIENT_CLOSE_UI, char)
+    _E6P("E6_NetCloseUI result: " .. tostring(result))
 end
 
 ---Ensure that the character's level limit is constrained to 6.
@@ -127,7 +128,7 @@ local function E6_OnRespecStart(characterGuid)
         return
     end
 
-    E6_NetCloseUI(characterGuid)
+    E6_NetCloseUI(GetEntityID(char))
     FeatPointTracker:OnRespecBegin(char)
 end
 

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_Init.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_Init.lua
@@ -3,6 +3,7 @@ Ext.Require("Server/E6_ApplyFeat.lua")
 Ext.Require("Server/E6_FeatPoints.lua")
 Ext.Require("Server/E6_SpellFeatHandler.lua")
 Ext.Require("Server/E6_NetServerHandlers.lua")
+Ext.Require("Server/E6_Commands.lua")
 Ext.Require("Server/E6_NetSubscribeEvents.lua")
 
 E6_FeatPointInit()

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_NetServerHandlers.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_NetServerHandlers.lua
@@ -33,45 +33,6 @@ function NetServerHandlers.SelectedFeatSpecification(_, payload, peerId)
     end
 end
 
----Exports the character's profile information to the file system as json. It skips numerous fields to avoid to much data (and redundancy).
----@param _ string The network message channel.
----@param payload any The selected feat.
----@param peerId integer The peer ID of the player.
-function NetServerHandlers.ExportCharacter(_, payload, peerId)
-    local entity = Ext.Entity.Get(payload)
-    if entity ~= nil then
-        --local datePrefix = os.date("%Y-%m-%d")
-        local character = GetCharacterName(entity)
-        E6_ToFile(entity, character .. "-Character-Export.json", {"Party", "ServerReplicationDependencyOwner", "InventoryContainer", "ServerRecruitedBy", "ServerOwneeHistory", "StatusManager"})
-    end
-end
-
----Exports the character's Epic 6 data to the file system as json.
----@param _ string The network message channel.
----@param payload any The selected feat.
----@param peerId integer The peer ID of the player.
-function NetServerHandlers.ExportEpicSix(_, payload, peerId)
-    local entity = Ext.Entity.Get(payload)
-    if not entity then
-        _E6Error("Failed to get the entity for the id:" .. payload)
-        return
-    end
-
-    --local datePrefix = os.date("%Y-%m-%d")
-    local playerInfo = GetFullPlayerInfo(entity)
-    if not playerInfo then
-        _E6Error("Failed to get the player info for: " .. payload)
-        return
-    end
-    local data = {
-        PlayerInfo = playerInfo,
-        SelectedFeats = entity.Vars.E6_Feats
-    }
-    local filename = playerInfo.Name .. "-EpicSix-Export.json"
-    Ext.IO.SaveFile(filename, Ext.Json.Stringify(data))
-    _E6P("Json data saved to %LOCALAPPDATA%\\Larian Studios\\Baldur's Gate 3\\Script Extender\\" .. filename .. ".")
-end
-
 ---Handles applying the selected feat for the current player.
 ---@param _ string The network message channel.
 ---@param payload any The selected feat.
@@ -193,10 +154,10 @@ function NetServerHandlers.RunTest(_, payload, peerId)
 
     -- Try to get Jaheira and set her AvailableLevel directly.
     -- Then test by retrieving it again and seeing what the value is.
-    TestLevels("S_Player_Jaheira")
+    --TestLevels("S_Player_Jaheira")
 
     -- Repeat for Minsc
-    TestLevels("S_Player_Minsc")
+    --TestLevels("S_Player_Minsc")
 end
 
 return NetServerHandlers

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_NetSubscribeEvents.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Server/E6_NetSubscribeEvents.lua
@@ -3,8 +3,6 @@ SubscribedEvents = {}
 local netEventsRegistry = CommandRegistry:new()
 
 netEventsRegistry:register(NetChannels.E6_CLIENT_TO_SERVER_SELECTED_FEAT_SPEC, NetCommand:new(NetServerHandlers.SelectedFeatSpecification))
-netEventsRegistry:register(NetChannels.E6_CLIENT_TO_SERVER_EXPORT_CHARACTER, NetCommand:new(NetServerHandlers.ExportCharacter))
-netEventsRegistry:register(NetChannels.E6_CLIENT_TO_SERVER_EXPORT_EPIC6, NetCommand:new(NetServerHandlers.ExportEpicSix))
 netEventsRegistry:register(NetChannels.E6_CLIENT_TO_SERVER_SET_XP_PER_FEAT, NetCommand:new(NetServerHandlers.SetXPPerFeat))
 netEventsRegistry:register(NetChannels.E6_CLIENT_TO_SERVER_SWITCH_CHARACTER, NetCommand:new(NetServerHandlers.SwitchCharacter))
 netEventsRegistry:register(NetChannels.E6_CLIENT_TO_SERVER_RESET_FEATS, NetCommand:new(NetServerHandlers.ResetFeats))

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Shared/E6_Init.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Shared/E6_Init.lua
@@ -20,23 +20,4 @@ local function DnDEpic6Init()
     Ext.Vars.RegisterModVariable(ModuleUUID, "E6_XPPerFeatIncrease", {Server = true, Client = false, SyncToClient = false})
 end
 
-local function TestFeatCount(xp, featXP, featXPDelta, expectedCount)
-    local count = GetFeatCountForXPBase(xp, featXP, featXPDelta)
-    local result = "XP=" .. tostring(xp) .. ", featXP=" .. tostring(featXP) .. ", featXPDelta=" .. tostring(featXPDelta) .. ", expected " .. tostring(expectedCount) .. " but got " .. tostring(count)
-    if count ~= expectedCount then
-        _E6Error(result)
-    else
-        _E6P(result)
-    end
-end
-
-local function TextFeatXP()
-    TestFeatCount(0, 1000, 0, 0)
-    TestFeatCount(1000, 1000, 0, 1)
-    TestFeatCount(1000, 1000, 1000, 1)
-    TestFeatCount(2000, 1000, 1, 1)
-    TestFeatCount(2001, 1000, 1, 2)
-end
-
 DnDEpic6Init()
---TextFeatXP()

--- a/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Shared/E6_NetChannels.lua
+++ b/DnD-Epic6/Mods/DnD-Epic6/ScriptExtender/Lua/Shared/E6_NetChannels.lua
@@ -8,10 +8,6 @@ NetChannels.E6_SERVER_TO_CLIENT_SHOW_FEAT_SELECTOR = "E6_Server_To_Client_Show_F
 NetChannels.E6_SERVER_TO_CLIENT_CLOSE_UI = "E6_Server_To_Client_Close_UI"
 -- Client to server message that contains the player id and the selected boosts to apply for the feat.
 NetChannels.E6_CLIENT_TO_SERVER_SELECTED_FEAT_SPEC = "E6_Client_To_Server_Selected_Feat_Spec"
--- Client to server message to export the character (expensive)
-NetChannels.E6_CLIENT_TO_SERVER_EXPORT_CHARACTER = "E6_Client_To_server_Export_Character"
--- Client to server mesage to export the epic six data, including what is sent from server to client for feat evaluation, the feat and passives for the player, and the feat point count.
-NetChannels.E6_CLIENT_TO_SERVER_EXPORT_EPIC6 = "E6_Client_To_server_Export_EpicSix"
 -- Client to server message to set the amount of experience to use per feat.
 NetChannels.E6_CLIENT_TO_SERVER_SET_XP_PER_FEAT = "E6_Client_To_Server_Set_XP_Per_Feat"
 -- Client to server message to switch the character to show feats for.
@@ -20,4 +16,5 @@ NetChannels.E6_CLIENT_TO_SERVER_SWITCH_CHARACTER = "E6_Client_To_Server_Switch_C
 NetChannels.E6_CLIENT_TO_SERVER_RESET_FEATS = "E6_Client_To_Server_Reset_Feats"
 ---Client to server message to run tests.
 NetChannels.E6_CLIENT_TO_SERVER_RUN_TEST = "E6_Client_To_Server_Run_Tests"
+
 return NetChannels

--- a/DnD-Epic6/Mods/DnD-Epic6/meta.lsx
+++ b/DnD-Epic6/Mods/DnD-Epic6/meta.lsx
@@ -32,10 +32,10 @@
           <attribute id="Tags" type="LSWString" value="XP;Progression;Leveling" />
           <attribute id="Type" type="FixedString" value="Add-on" />
           <attribute id="UUID" type="FixedString" value="c8ecf3dd-b5ab-4041-b2e0-d2197845342f" />
-          <attribute id="Version64" type="int64" value="36169583899444690" />
+          <attribute id="Version64" type="int64" value="36169583899444697" />
           <children>
             <node id="PublishVersion">
-              <attribute id="Version64" type="int64" value="36169583899444690" />
+              <attribute id="Version64" type="int64" value="36169583899444697" />
             </node>
             <node id="Scripts" />
             <node id="TargetModes">


### PR DESCRIPTION
The commands to fix summon levels shows that adjusting the available or eoc level of the entity doesn't change anything (tested with summons in particular). So I won't bother writing any code to have this effect at runtime. Leaving the test code as reference.